### PR TITLE
'cms_login' not found

### DIFF
--- a/djangocms_multisite/urlresolvers.py
+++ b/djangocms_multisite/urlresolvers.py
@@ -13,6 +13,7 @@ from cms.appresolver import get_app_patterns
 from cms.constants import SLUG_REGEXP
 from cms.signals import urls_need_reloading
 from cms.views import details
+from cms import views
 
 MULTISITE_PATTERNS = {}
 if settings.APPEND_SLASH:
@@ -46,7 +47,8 @@ class CMSMultisiteRegexURLResolver(RegexURLResolver):
             else:
                 urlpatterns = []
 
-            urlpatterns.extend([
+            urlpatterns.extend([                
+                url(r'^cms_login/$', views.login, name='cms_login'),
                 url(r'^cms_wizard/', include('cms.wizards.urls')),
                 url(regexp, details, name='pages-details-by-slug'),
                 url(r'^$', details, {'slug': ''}, name='pages-root'),


### PR DESCRIPTION
django==1.11.11 django-cms=3.5.1  python35 python36

Without this modification, this happens with cms_multisite_url :
django.urls.exceptions.NoReverseMatch: Reverse for 'cms_login' not found. 'cms_login' is not a valid view function or pattern name.